### PR TITLE
internal/pool, baseClient: instrument with OpenCensus

### DIFF
--- a/internal/observability/helpers.go
+++ b/internal/observability/helpers.go
@@ -1,0 +1,15 @@
+package observability
+
+import (
+	"context"
+
+	"go.opencensus.io/tag"
+)
+
+func TagKeyValuesIntoContext(ctx context.Context, key tag.Key, values ...string) (context.Context, error) {
+	insertions := make([]tag.Mutator, len(values))
+	for i, value := range values {
+		insertions[i] = tag.Insert(key, value)
+	}
+	return tag.New(ctx, insertions...)
+}

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -1,0 +1,130 @@
+package observability
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// Pool metrics:
+// 1. Connections taken
+// 2. Connections closed
+// 3. Connections usetime -- how long is a connection used until it is closed, discarded or returned
+// 4. Connections reused
+// 4. Connections stale
+// 5. Dial errors
+
+const dimensionless = "1"
+const unitSeconds = "s"
+
+var (
+	MBytesRead           = stats.Int64("redis/bytes_read", "The number of bytes read from the server", stats.UnitBytes)
+	MBytesWritten        = stats.Int64("redis/bytes_written", "The number of bytes written out to the server", stats.UnitBytes)
+	MDialErrors          = stats.Int64("redis/dial_errors", "The number of dial errors", dimensionless)
+	MConnectionsTaken    = stats.Int64("redis/connections_taken", "The number of connections taken", dimensionless)
+	MConnectionsClosed   = stats.Int64("redis/connections_closed", "The number of connections closed", dimensionless)
+	MConnectionsReturned = stats.Int64("redis/connections_returned", "The number of connections returned to the pool", dimensionless)
+	MConnectionsReused   = stats.Int64("redis/connections_reused", "The number of connections reused", dimensionless)
+	MConnectionsNew      = stats.Int64("redis/connections_new", "The number of newly created connections", dimensionless)
+	MConnectionUseTime   = stats.Float64("redis/connection_usetime", "The number of seconds for which a connection is used", unitSeconds)
+	MRoundtripLatency    = stats.Float64("redis/roundtrip_latency", "The time between sending the first byte to the server until the last byte of response is received back", unitSeconds)
+	MWriteErrors         = stats.Int64("redis/write_errors", "The number of errors encountered during write routines", dimensionless)
+	MWrites              = stats.Int64("redis/writes", "The number of write invocations", dimensionless)
+)
+
+var KeyCommandName, _ = tag.NewKey("cmd")
+
+var defaultSecondsDistribution = view.Distribution(
+	// [0ms, 0.01ms, 0.05ms, 0.1ms, 0.5ms, 1ms, 1.5ms, 2ms, 2.5ms, 5ms, 10ms, 25ms, 50ms, 100ms, 200ms, 400ms, 600ms, 800ms, 1s, 1.5s, 2.5s, 5s, 10s, 20s, 40s, 100s, 200s, 500s]
+	0, 0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.0015, 0.002, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1, 1.5, 2.5, 5, 10, 20, 40, 100, 200, 500,
+)
+
+var defaultBytesDistribution = view.Distribution(
+	// [0, 1KB, 2KB, 4KB, 16KB, 64KB, 256KB,   1MB,     4MB,     16MB,     64MB,     256MB,     1GB,        4GB]
+	0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296,
+)
+
+var Views = []*view.View{
+	{
+		Name:        "redis/client/connection_usetime",
+		Description: "The duration in seconds for which a connection is used before being returned to the pool, closed or discarded",
+
+		Aggregation: defaultSecondsDistribution,
+		Measure:     MConnectionUseTime,
+	},
+	{
+		Name:        "redis/client/dial_errors",
+		Description: "The number of errors encountered after dialling",
+		Aggregation: view.Count(),
+		Measure:     MDialErrors,
+	},
+	{
+		Name:        "redis/client/bytes_written_cummulative",
+		Description: "The number of bytes written out to the server",
+		Aggregation: view.Count(),
+		Measure:     MBytesWritten,
+	},
+	{
+		Name:        "redis/client/bytes_written_distribution",
+		Description: "The number of distribution of bytes written out to the server",
+		Aggregation: defaultBytesDistribution,
+		Measure:     MBytesWritten,
+	},
+	{
+		Name:        "redis/client/bytes_read_cummulative",
+		Description: "The number of bytes read from a response from the server",
+		Aggregation: view.Count(),
+		Measure:     MBytesRead,
+	},
+	{
+		Name:        "redis/client/bytes_read_distribution",
+		Description: "The number of distribution of bytes read from the server",
+		Aggregation: defaultBytesDistribution,
+		Measure:     MBytesRead,
+	},
+	{
+		Name:        "redis/client/roundtrip_latency",
+		Description: "The distribution of seconds of the roundtrip latencies",
+		Aggregation: defaultSecondsDistribution,
+		Measure:     MRoundtripLatency,
+		TagKeys:     []tag.Key{KeyCommandName},
+	},
+	{
+		Name:        "redis/client/write_errors",
+		Description: "The number of errors encountered during a write routine",
+		Aggregation: view.Count(),
+		Measure:     MWriteErrors,
+		TagKeys:     []tag.Key{KeyCommandName},
+	},
+	{
+		Name:        "redis/client/writes",
+		Description: "The number of write invocations",
+		Aggregation: view.Count(),
+		Measure:     MWrites,
+		TagKeys:     []tag.Key{KeyCommandName},
+	},
+	{
+		Name:        "redis/client/connections_taken",
+		Description: "The number of connections taken out the pool",
+		Aggregation: view.Count(),
+		Measure:     MConnectionsTaken,
+	},
+	{
+		Name:        "redis/client/connections_returned",
+		Description: "The number of connections returned the connection pool",
+		Aggregation: view.Count(),
+		Measure:     MConnectionsReturned,
+	},
+	{
+		Name:        "redis/client/connections_reused",
+		Description: "The number of connections reused",
+		Aggregation: view.Count(),
+		Measure:     MConnectionsReused,
+	},
+	{
+		Name:        "redis/client/connections_new",
+		Description: "The number of newly created connections",
+		Aggregation: view.Count(),
+		Measure:     MConnectionsNew,
+	},
+}

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -15,26 +15,26 @@ import (
 // 5. Dial errors
 
 const dimensionless = "1"
-const unitSeconds = "s"
+const unitMilliseconds = "ms"
 
 var (
-	MBytesRead           = stats.Int64("redis/bytes_read", "The number of bytes read from the server", stats.UnitBytes)
-	MBytesWritten        = stats.Int64("redis/bytes_written", "The number of bytes written out to the server", stats.UnitBytes)
-	MDialErrors          = stats.Int64("redis/dial_errors", "The number of dial errors", dimensionless)
-	MConnectionsTaken    = stats.Int64("redis/connections_taken", "The number of connections taken", dimensionless)
-	MConnectionsClosed   = stats.Int64("redis/connections_closed", "The number of connections closed", dimensionless)
-	MConnectionsReturned = stats.Int64("redis/connections_returned", "The number of connections returned to the pool", dimensionless)
-	MConnectionsReused   = stats.Int64("redis/connections_reused", "The number of connections reused", dimensionless)
-	MConnectionsNew      = stats.Int64("redis/connections_new", "The number of newly created connections", dimensionless)
-	MConnectionUseTime   = stats.Float64("redis/connection_usetime", "The number of seconds for which a connection is used", unitSeconds)
-	MRoundtripLatency    = stats.Float64("redis/roundtrip_latency", "The time between sending the first byte to the server until the last byte of response is received back", unitSeconds)
-	MWriteErrors         = stats.Int64("redis/write_errors", "The number of errors encountered during write routines", dimensionless)
-	MWrites              = stats.Int64("redis/writes", "The number of write invocations", dimensionless)
+	MBytesRead                     = stats.Int64("redis/bytes_read", "The number of bytes read from the server", stats.UnitBytes)
+	MBytesWritten                  = stats.Int64("redis/bytes_written", "The number of bytes written out to the server", stats.UnitBytes)
+	MDialErrors                    = stats.Int64("redis/dial_errors", "The number of dial errors", dimensionless)
+	MConnectionsTaken              = stats.Int64("redis/connections_taken", "The number of connections taken", dimensionless)
+	MConnectionsClosed             = stats.Int64("redis/connections_closed", "The number of connections closed", dimensionless)
+	MConnectionsReturned           = stats.Int64("redis/connections_returned", "The number of connections returned to the pool", dimensionless)
+	MConnectionsReused             = stats.Int64("redis/connections_reused", "The number of connections reused", dimensionless)
+	MConnectionsNew                = stats.Int64("redis/connections_new", "The number of newly created connections", dimensionless)
+	MConnectionUseTimeMilliseconds = stats.Float64("redis/connection_usetime", "The number of milliseconds for which a connection is used", unitMilliseconds)
+	MRoundtripLatencyMilliseconds  = stats.Float64("redis/roundtrip_latency", "The time between sending the first byte to the server until the last byte of response is received back", unitMilliseconds)
+	MWriteErrors                   = stats.Int64("redis/write_errors", "The number of errors encountered during write routines", dimensionless)
+	MWrites                        = stats.Int64("redis/writes", "The number of write invocations", dimensionless)
 )
 
 var KeyCommandName, _ = tag.NewKey("cmd")
 
-var defaultSecondsDistribution = view.Distribution(
+var defaultMillisecondsDistribution = view.Distribution(
 	// [0ms, 0.01ms, 0.05ms, 0.1ms, 0.5ms, 1ms, 1.5ms, 2ms, 2.5ms, 5ms, 10ms, 25ms, 50ms, 100ms, 200ms, 400ms, 600ms, 800ms, 1s, 1.5s, 2.5s, 5s, 10s, 20s, 40s, 100s, 200s, 500s]
 	0, 0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.0015, 0.002, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1, 1.5, 2.5, 5, 10, 20, 40, 100, 200, 500,
 )
@@ -47,10 +47,10 @@ var defaultBytesDistribution = view.Distribution(
 var Views = []*view.View{
 	{
 		Name:        "redis/client/connection_usetime",
-		Description: "The duration in seconds for which a connection is used before being returned to the pool, closed or discarded",
+		Description: "The duration in milliseconds for which a connection is used before being returned to the pool, closed or discarded",
 
-		Aggregation: defaultSecondsDistribution,
-		Measure:     MConnectionUseTime,
+		Aggregation: defaultMillisecondsDistribution,
+		Measure:     MConnectionUseTimeMilliseconds,
 	},
 	{
 		Name:        "redis/client/dial_errors",
@@ -84,9 +84,9 @@ var Views = []*view.View{
 	},
 	{
 		Name:        "redis/client/roundtrip_latency",
-		Description: "The distribution of seconds of the roundtrip latencies",
-		Aggregation: defaultSecondsDistribution,
-		Measure:     MRoundtripLatency,
+		Description: "The distribution of milliseconds of the roundtrip latencies",
+		Aggregation: defaultMillisecondsDistribution,
+		Measure:     MRoundtripLatencyMilliseconds,
 		TagKeys:     []tag.Key{KeyCommandName},
 	},
 	{

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -66,6 +66,7 @@ func (cn *Conn) SetWriteTimeout(timeout time.Duration) error {
 }
 
 func (cn *Conn) Write(b []byte) (int, error) {
+	// TODO: Stats: (@odeke-em) Record written bytes
 	return cn.netConn.Write(b)
 }
 
@@ -74,5 +75,6 @@ func (cn *Conn) RemoteAddr() net.Addr {
 }
 
 func (cn *Conn) Close() error {
+	// TODO: Stats: (@odeke-em) Record Conn closes
 	return cn.netConn.Close()
 }

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -133,6 +133,7 @@ func (p *ConnPool) tryDial() {
 			continue
 		}
 
+		// TODO: Stats: (@odeke-em) Record successful dial
 		atomic.StoreUint32(&p.dialErrorsNum, 0)
 		_ = conn.Close()
 		return
@@ -173,6 +174,7 @@ func (p *ConnPool) Get() (*Conn, bool, error) {
 		case <-timer.C:
 			timers.Put(timer)
 			atomic.AddUint32(&p.stats.Timeouts, 1)
+			// TODO: Stats: (@odeke-em) Record Pool timeouts
 			return nil, false, ErrPoolTimeout
 		}
 	}
@@ -187,10 +189,12 @@ func (p *ConnPool) Get() (*Conn, bool, error) {
 		}
 
 		if cn.IsStale(p.opt.IdleTimeout) {
+			// TODO: Stats: (@odeke-em) Record stale connection
 			p.CloseConn(cn)
 			continue
 		}
 
+		// TODO: Stats: (@odeke-em) Record reused connection
 		atomic.AddUint32(&p.stats.Hits, 1)
 		return cn, false, nil
 	}
@@ -203,6 +207,7 @@ func (p *ConnPool) Get() (*Conn, bool, error) {
 		return nil, false, err
 	}
 
+	// TODO: Stats: (@odeke-em) Record taken connection
 	return newcn, true, nil
 }
 
@@ -226,6 +231,7 @@ func (p *ConnPool) Put(cn *Conn) error {
 	p.freeConns = append(p.freeConns, cn)
 	p.freeConnsMu.Unlock()
 	<-p.queue
+	// TODO: Stats: (@odeke-em) Record Conn Put
 	return nil
 }
 
@@ -252,6 +258,7 @@ func (p *ConnPool) closeConn(cn *Conn) error {
 	if p.opt.OnClose != nil {
 		_ = p.opt.OnClose(cn)
 	}
+	// TODO: Stats: (@odeke-em) Record Conn Close
 	return cn.Close()
 }
 

--- a/observability.go
+++ b/observability.go
@@ -1,5 +1,0 @@
-package redis
-
-import "github.com/go-redis/redis/internal/observability"
-
-var ObservabilityMetricViews = observability.Views

--- a/observability.go
+++ b/observability.go
@@ -1,0 +1,5 @@
+package redis
+
+import "github.com/go-redis/redis/internal/observability"
+
+var ObservabilityMetricViews = observability.Views

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -77,6 +78,9 @@ type Options struct {
 
 	// TLS Config to use. When set TLS will be negotiated.
 	TLSConfig *tls.Config
+
+	// The initial context
+	Context context.Context
 }
 
 func (opt *Options) init() {

--- a/pubsub.go
+++ b/pubsub.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -100,7 +101,8 @@ func (c *PubSub) _subscribe(cn *pool.Conn, redisCmd string, channels ...string) 
 	cmd := NewSliceCmd(args...)
 
 	cn.SetWriteTimeout(c.opt.WriteTimeout)
-	return writeCmd(cn, cmd)
+	// TODO: (@odeke-em) use the propagated context
+	return writeCmd(context.Background(), cn, cmd)
 }
 
 func (c *PubSub) releaseConn(cn *pool.Conn, err error) {
@@ -217,7 +219,8 @@ func (c *PubSub) Ping(payload ...string) error {
 	}
 
 	cn.SetWriteTimeout(c.opt.WriteTimeout)
-	err = writeCmd(cn, cmd)
+	// TODO: (@odeke-em) use the propagated context
+	err = writeCmd(context.Background(), cn, cmd)
 	c.releaseConn(cn, err)
 	return err
 }

--- a/redis.go
+++ b/redis.go
@@ -168,7 +168,7 @@ func (c *baseClient) defaultProcess(cmd Cmder) error {
 	defer func() {
 		span.End()
 		// Finally record the roundtrip latency.
-		stats.Record(ctx, observability.MRoundtripLatency.M(time.Since(startTime).Seconds()))
+		stats.Record(ctx, observability.MRoundtripLatencyMilliseconds.M(time.Since(startTime).Seconds()*1000))
 	}()
 
 	for attempt := 0; attempt <= c.opt.MaxRetries; attempt++ {

--- a/ring.go
+++ b/ring.go
@@ -525,7 +525,7 @@ func (c *Ring) defaultProcessPipeline(cmds []Cmder) error {
 				continue
 			}
 
-			cn, _, err := shard.Client.getConn()
+			cn, _, err := shard.Client.getConn(c.Context())
 			if err != nil {
 				setCmdsErr(cmds, err)
 				continue


### PR DESCRIPTION
Given:

### Server
```go
package main

import (
	"context"
	"encoding/json"
	"io"
	"io/ioutil"
	"log"
	"net/http"

	"github.com/go-redis/redis"
	"github.com/orijtech/otils"

	"go.opencensus.io/exporter/stackdriver"
	"go.opencensus.io/plugin/ochttp"
	"go.opencensus.io/stats/view"
	"go.opencensus.io/trace"
)

func main() {
	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
	se, err := stackdriver.NewExporter(stackdriver.Options{
		ProjectID:    "census-demos",
		MetricPrefix: "cmstore",
	})
	if err != nil {
		log.Fatalf("Failed to create Stackdriver exporter: %v", err)
	}
	trace.RegisterExporter(se)
	view.RegisterExporter(se)
	if err := view.Register(ochttp.DefaultServerViews...); err != nil {
		log.Fatalf("Failed to register server views: %v", err)
	}
	if err := view.Register(ochttp.DefaultClientViews...); err != nil {
		log.Fatalf("Failed to register client views: %v", err)
	}
	if err := view.Register(redis.ObservabilityMetricViews...); err != nil {
		log.Fatalf("Failed to register redis observability metric views: %v", err)
	}

	mux := http.NewServeMux()
	mux.HandleFunc("/hdel", hdel)
	mux.HandleFunc("/hget", hget)
	mux.HandleFunc("/hset", hset)
	h := &ochttp.Handler{Handler: mux}
	if err := http.ListenAndServe(":9889", h); err != nil {
		log.Fatalf("Failed to serve: %v", err)
	}
}

type params struct {
	Table string `json:"table"`
	Key   string `json:"key"`
	Value string `json:"value"`
}

func hget(w http.ResponseWriter, r *http.Request) {
	ctx, span := trace.StartSpan(r.Context(), "hget")
	defer span.End()

	client := newRedisClient(ctx)
	defer client.Close()

	pm := new(params)
	if err := parseJSON(r.Body, pm); err != nil {
		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
		return
	}
	val, err := client.HGet(pm.Table, pm.Key).Result()
	errStr := ""
	if err != nil {
		errStr = err.Error()
	}
	outBlob, err := json.MarshalIndent(map[string]string{
		"value": val,
		"err":   errStr,
	}, "", "  ")
	if err != nil {
		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
		return
	}
	w.Write(outBlob)
}

func newRedisClient(ctx context.Context) *redis.Client {
	return redis.NewClient(&redis.Options{
		Addr:    otils.EnvOrAlternates("REDIS_SERVER_ADDR", ":6379"),
		Context: ctx,
	})
}

func hdel(w http.ResponseWriter, r *http.Request) {
	ctx, span := trace.StartSpan(r.Context(), "hdel")
	defer span.End()

	client := newRedisClient(ctx)
	defer client.Close()

	pm := new(params)
	if err := parseJSON(r.Body, pm); err != nil {
		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
		return
	}
	val, err := client.HDel(pm.Table, pm.Key).Result()
	errStr := ""
	if err != nil {
		errStr = err.Error()
	}
	outBlob, err := json.MarshalIndent(map[string]interface{}{
		"value": val,
		"err":   errStr,
	}, "", "  ")
	if err != nil {
		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
		return
	}
	w.Write(outBlob)
}

func parseJSON(rc io.ReadCloser, save interface{}) error {
	blob, err := ioutil.ReadAll(rc)
	_ = rc.Close()
	if err != nil {
		return err
	}
	return json.Unmarshal(blob, save)
}

func hset(w http.ResponseWriter, r *http.Request) {
	ctx, span := trace.StartSpan(r.Context(), "hset")
	defer span.End()

	client := newRedisClient(ctx)
	defer client.Close()

	pm := new(params)
	if err := parseJSON(r.Body, pm); err != nil {
		span.SetStatus(trace.Status{Code: int32(trace.StatusCodeInternal), Message: err.Error()})
		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
		return
	}

	ok, err := client.HSet(pm.Table, pm.Key, pm.Value).Result()
	errStr := ""
	if err != nil {
		errStr = err.Error()
	}
	outBlob, err := json.MarshalIndent(map[string]interface{}{
		"ok":  ok,
		"err": errStr,
	}, "", "  ")
	if err != nil {
		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
		return
	}
	w.Write(outBlob)

}
```

### Client
```go
package main

import (
	"bytes"
	"fmt"
	"io/ioutil"
	"math/rand"
	"net/http"
	"time"
)

func main() {
	bodies := []string{
		`{"table": "stories", "key":"foo", "value":"ghost"}`,
		`{"table": "protocols", "key":"version", "value":"ipv4"}`,
		`{"table": "devices", "key":"Kindle", "value":"v1"}`,
		`{"table": "customers", "key":"Barnes & Noble", "value":"ox"}`,
	}
	routes := []string{
		"/hset",
		"/hdel",
		"/hget",
	}

	rand.Seed(time.Now().Unix())
	for i := uint64(0); ; i++ {
		// Pick a random route
		routePerm := rand.Perm(len(routes))
		for _, ithRoute := range routePerm {
			bodiesPerm := rand.Perm(len(bodies))
			for _, ithBody := range bodiesPerm {
				body := []byte(bodies[ithBody])
				route := routes[ithRoute]
				req, _ := http.NewRequest("POST", "http://localhost:9889"+route, bytes.NewReader(body))
				res, _ := http.DefaultClient.Do(req)
				resBlob, _ := ioutil.ReadAll(res.Body)
				_ = res.Body.Close()
				fmt.Printf("#%d (%s) ==> %s\n\n", i, route, resBlob)
			}
		}
		sleepDuration := time.Millisecond * time.Duration(rand.Float64()*2e3)
		fmt.Printf("Sleeping for %s\n", sleepDuration)
		time.Sleep(sleepDuration)
	}
}
```


## Tracing results
![screen shot 2018-05-27 at 9 02 19 pm](https://user-images.githubusercontent.com/4898263/40596710-8edbb0d4-61f1-11e8-9d4c-bbee64582361.png)

## Monitoring results
![screen shot 2018-05-27 at 9 02 41 pm](https://user-images.githubusercontent.com/4898263/40596708-8b0a49ac-61f1-11e8-857b-9671a7a117d9.png)
![screen shot 2018-05-27 at 9 03 57 pm](https://user-images.githubusercontent.com/4898263/40596704-8ab0292c-61f1-11e8-8aa4-80ec9f5e3eed.png)
![screen shot 2018-05-27 at 9 03 40 pm](https://user-images.githubusercontent.com/4898263/40596705-8ac6fb16-61f1-11e8-8094-13dcb2053c7f.png)
![screen shot 2018-05-27 at 9 03 20 pm](https://user-images.githubusercontent.com/4898263/40596706-8ae13062-61f1-11e8-8436-3b4c9652b65c.png)
![screen shot 2018-05-27 at 9 03 06 pm](https://user-images.githubusercontent.com/4898263/40596707-8af5b3ca-61f1-11e8-9482-738f4d7fffb8.png)
